### PR TITLE
update according to changes in latest mix_erllambda

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule ErllambdaElixirExample.MixProject do
   defp deps do
     [
       {:erllambda, "~> 2.0"},
-      {:mix_erllambda, "~> 1.0"},
+      {:mix_erllambda, "~> 1.1"},
       {:jiffy, "~> 0.15.2"}
     ]
   end

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -7,7 +7,7 @@
 |> Path.wildcard()
 |> Enum.map(&Code.eval_file(&1))
 
-use Mix.Releases.Config,
+use Distillery.Releases.Config,
     # This sets the default release built by `mix release`
     default_release: :default,
     # This sets the default environment used by `mix release`


### PR DESCRIPTION
requires https://github.com/alertlogic/mix_erllambda/pull/8 and assumes `mix_erllambda` will have version `1.1` after the PR is merged.